### PR TITLE
swithing back to using npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,16 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
+        cache: 'npm'
 
-    - run: yarn
+    - run: npm i
 
-    - run: yarn add sass
+    - run: npm install sass
 
-    - run: yarn run build --if-present
+    - run: npm run build --if-present
 
     - name: Run the tests and generate coverage report
-      run: yarn run test -- --coverage
+      run: npm test -- --coverage
 
     - name: Codecov
       uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
Switching back to npm due to
```
error react-flow-renderer@10.2.1: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.12"
error Found incompatible module.
```
error during build